### PR TITLE
Add instructor only translation to all files

### DIFF
--- a/public/language/ar/error.json
+++ b/public/language/ar/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "مقتطف غير موجود",
     "no-flag": "Flag does not exist",
     "no-privileges": "لاتملك الصلاحيات اللازمة للقيام بهذه العملية",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "قائمة معطلة",
     "topic-locked": "الموضوع مقفول",
     "post-edit-duration-expired": "يسمح لك بتعديل مشاركتك حتى %1 ثانية من نشرها",

--- a/public/language/bg/error.json
+++ b/public/language/bg/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Резюмето не съществува",
     "no-flag": "Докладът не съществува",
     "no-privileges": "Нямате достатъчно права за това действие.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Категорията е изключена",
     "topic-locked": "Темата е заключена",
     "post-edit-duration-expired": "Можете да редактирате публикациите си до %1 секунда/и, след като ги пуснете",

--- a/public/language/bn/error.json
+++ b/public/language/bn/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "টিজারটি খুজে পাওয়া যায় নি",
     "no-flag": "Flag does not exist",
     "no-privileges": "এই কাজটির জন্য আপনার পর্যাপ্ত অধিকার নেই",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "বিভাগটি নিষ্ক্রিয়",
     "topic-locked": "টপিক বন্ধ",
     "post-edit-duration-expired": "You are only allowed to edit posts for %1 second(s) after posting",

--- a/public/language/cs/error.json
+++ b/public/language/cs/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Chyták neexistuje",
     "no-flag": "Flag does not exist",
     "no-privileges": "Na tuto akci nemáte dostatečné oprávnění.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorie zakázána",
     "topic-locked": "Téma uzamknuto",
     "post-edit-duration-expired": "Je vám umožněno upravit příspěvky jen po %1 sekund/y od jeho vytvoření",

--- a/public/language/da/error.json
+++ b/public/language/da/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaser eksisterer ikke",
     "no-flag": "Flag does not exist",
     "no-privileges": "Du har ikke nok rettigheder til at udføre denne handling",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorien er deaktiveret",
     "topic-locked": "Tråden er låst",
     "post-edit-duration-expired": "Du kan kun redigere indlæg i %1 sekund(er) efter indlæg",

--- a/public/language/de/error.json
+++ b/public/language/de/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Zusammenfassung existiert nicht",
     "no-flag": "Markierung existiert nicht",
     "no-privileges": "Du verfügst nicht über ausreichende Berechtigungen, um die Aktion durchzuführen.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorie ist deaktiviert",
     "topic-locked": "Thema ist gesperrt",
     "post-edit-duration-expired": "Entschuldigung, du darfst Beiträge nur %1 Sekunde(n) nach dem Veröffentlichen editieren.",

--- a/public/language/el/error.json
+++ b/public/language/el/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaser does not exist",
     "no-flag": "Flag does not exist",
     "no-privileges": "You do not have enough privileges for this action.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Η κατηγορία έχει απενεργοποιηθεί",
     "topic-locked": "Το θέμα έχει κλειδωθεί",
     "post-edit-duration-expired": "You are only allowed to edit posts for %1 second(s) after posting",

--- a/public/language/en-x-pirate/error.json
+++ b/public/language/en-x-pirate/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaser does not exist",
     "no-flag": "Flag does not exist",
     "no-privileges": "You do not have enough privileges for this action.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Category disabled",
     "topic-locked": "Topic Locked",
     "post-edit-duration-expired": "You are only allowed to edit posts for %1 second(s) after posting",

--- a/public/language/es/error.json
+++ b/public/language/es/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "El resumen no existe",
     "no-flag": "Flag does not exist",
     "no-privileges": "No tienes suficientes privilegios para realizar esta acción.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Categoría deshabilitada",
     "topic-locked": "Tema bloqueado",
     "post-edit-duration-expired": "Sólo puedes editar mensajes durante %1 segundo(s) después de haberlo escrito",

--- a/public/language/et/error.json
+++ b/public/language/et/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Eelvaadet ei eksisteeri",
     "no-flag": "Flag does not exist",
     "no-privileges": "Sul pole piisavalt õigusi.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategooria keelatud",
     "topic-locked": "Teema lukustatud",
     "post-edit-duration-expired": "Te peate ootama %1 sekund(it), enne kui oma postitust muudate.",

--- a/public/language/fa-IR/error.json
+++ b/public/language/fa-IR/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "تیزر وجود ندارد",
     "no-flag": "Flag does not exist",
     "no-privileges": "شما دسترسی کافی برای این کار را ندارید",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "دسته غیر‌فعال شد.",
     "topic-locked": "موضوع بسته شد.",
     "post-edit-duration-expired": "شما تنها می توانید %1 ثانیه پس از فرستادن پست آن‌را ویرایش کنید",

--- a/public/language/fi/error.json
+++ b/public/language/fi/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaser does not exist",
     "no-flag": "Flag does not exist",
     "no-privileges": "Oikeutesi eivät riitä toiminnon suorittamiseen.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategoria ei ole käytössä",
     "topic-locked": "Aihe lukittu",
     "post-edit-duration-expired": "You are only allowed to edit posts for %1 second(s) after posting",

--- a/public/language/fr/error.json
+++ b/public/language/fr/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "L’aperçu n'existe pas",
     "no-flag": "Le signalement n'existe pas",
     "no-privileges": "Vous n'avez pas les privilèges nécessaires pour effectuer cette action.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Catégorie désactivée",
     "topic-locked": "Sujet verrouillé",
     "post-edit-duration-expired": "Vous ne pouvez modifier un message que pendant %1 seconde(s) après l'avoir posté.",

--- a/public/language/gl/error.json
+++ b/public/language/gl/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "A vista previa do tema non existe",
     "no-flag": "Flag does not exist",
     "no-privileges": "Non tes privilexios dabondo para ver este tema.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Categoría deshabilitada",
     "topic-locked": "Tema Pechado",
     "post-edit-duration-expired": "Só podes editar as publicacións %1 segundo(s) despois de envialas. ",

--- a/public/language/he/error.json
+++ b/public/language/he/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "תקציר אינו קיים",
     "no-flag": "דיווח לא קיים",
     "no-privileges": "ההרשאות שלכם אינן מספיקות לביצוע פעולה זו.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "קטגוריה לא פעילה",
     "topic-locked": "נושא נעול",
     "post-edit-duration-expired": "ניתן לערוך פוסטים עד %1 שניות מרגע כתיבת הפוסט",

--- a/public/language/hr/error.json
+++ b/public/language/hr/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Zadirkivač ne postoji",
     "no-flag": "Flag does not exist",
     "no-privileges": "Nemate privilegije za ovu radnju.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorija onemogućena",
     "topic-locked": "Tema zaključana",
     "post-edit-duration-expired": "Dozvoljeno vam je uređivanje %1 sekundi nakon objave",

--- a/public/language/hu/error.json
+++ b/public/language/hu/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "A bevezető nem létezik",
     "no-flag": "Flag does not exist",
     "no-privileges": "Nincs elég jogod ehhez a művelethez.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategória kikapcsolva",
     "topic-locked": "Téma lezárva",
     "post-edit-duration-expired": "Bejegyzés létrehozását követően csak %1 másodperc elteltével válik szerkeszthetővé",

--- a/public/language/hy/error.json
+++ b/public/language/hy/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Թիզերը գոյություն չունի",
     "no-flag": "Դրոշ գոյություն չունի",
     "no-privileges": "Դուք չունեք բավարար արտոնություններ այս գործողության համար:",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Կատեգորիան անջատված է",
     "topic-locked": "Թեման փակված է",
     "post-edit-duration-expired": "Ձեզ թույլատրվում է խմբագրել հաղորդագրությունները կիսվելուց միայն %1 վայրկյան հետո։",

--- a/public/language/id/error.json
+++ b/public/language/id/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaser tidak ditemukan",
     "no-flag": "Flag does not exist",
     "no-privileges": "Kamu tidak punya cukup izin untuk melakukan ini",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategori ditiadakan",
     "topic-locked": "Topik dikunci",
     "post-edit-duration-expired": "You are only allowed to edit posts for %1 second(s) after posting",

--- a/public/language/it/error.json
+++ b/public/language/it/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaser non esiste",
     "no-flag": "Segnalazione non esiste",
     "no-privileges": "Non hai abbastanza privilegi per questa azione.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Categoria disabilitata",
     "topic-locked": "Discussione Bloccata",
     "post-edit-duration-expired": "Puoi modificare i post solo per %1 secondo(i) dopo la pubblicazione",

--- a/public/language/ja/error.json
+++ b/public/language/ja/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "ティーザーが存在しません",
     "no-flag": "Flag does not exist",
     "no-privileges": "あなたがこの行為する権利がありません。",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "この板は無効された",
     "topic-locked": "スレッドがロックされた",
     "post-edit-duration-expired": "あなたが%1秒後に投稿を編集する事が許されます",

--- a/public/language/ko/error.json
+++ b/public/language/ko/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "존재하지 않는 미리보기입니다.",
     "no-flag": "Flag does not exist",
     "no-privileges": "이 작업을 할 수 있는 권한이 없습니다.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "카테고리가 비활성화 되었습니다.",
     "topic-locked": "게시물이 잠금 상태입니다.",
     "post-edit-duration-expired": "포스트의 수정은 작성한 시간으로부터 %1초 후에 가능합니다.",

--- a/public/language/lt/error.json
+++ b/public/language/lt/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Anonsas neegzistuoja",
     "no-flag": "Flag does not exist",
     "no-privileges": "Šiam veiksmui jūs neturite pakankamų privilegijų.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorija išjungta",
     "topic-locked": "Tema užrakinta",
     "post-edit-duration-expired": "Jums galima redaguoti pranešims tik %1 sekunde(s) po parašymo",

--- a/public/language/lv/error.json
+++ b/public/language/lv/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Ievadapraksts nav atrasts",
     "no-flag": "Flag does not exist",
     "no-privileges": "Tev nepietiek tiesības šai darbībai.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorija ir atspējota",
     "topic-locked": "Temats ir slēgts",
     "post-edit-duration-expired": "Rakstus drīkst rediģēt tikai līdz %1 sekundēm pēc publicēšanas",

--- a/public/language/ms/error.json
+++ b/public/language/ms/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Pengusik tidak wujud",
     "no-flag": "Flag does not exist",
     "no-privileges": "Anda tidak mempunyai cukup keistimewaan untuk perbuatan ini.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategori dilumpuhkan",
     "topic-locked": "Topik Dikunci",
     "post-edit-duration-expired": "Anda hanya dibenarkan menyunting kiriman selepas %1 saat() berlalu",

--- a/public/language/nb/error.json
+++ b/public/language/nb/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaseren eksisterer ikke",
     "no-flag": "Flag does not exist",
     "no-privileges": "Du har ikke nok rettigheter til å utføre denne handlingen.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategori deaktivert",
     "topic-locked": "Emne låst",
     "post-edit-duration-expired": "Du har bare lov til å redigere innlegg i %1 sekund(er) etter at det er sendt",

--- a/public/language/nl/error.json
+++ b/public/language/nl/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Dit voorproefje bestaat niet",
     "no-flag": "Flag does not exist",
     "no-privileges": "Onvoldoende rechten om deze actie uit te voeren",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Categorie uitgeschakeld",
     "topic-locked": "Onderwerp gesloten",
     "post-edit-duration-expired": "Het is slechts toegestaan om binnen %1 seconde(n) na plaatsen van het bericht, deze te bewerken.",

--- a/public/language/pl/error.json
+++ b/public/language/pl/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Zwiastun nie istnieje",
     "no-flag": "Flag does not exist",
     "no-privileges": "Nie masz przywileju wykonywania tej akcji",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategoria wyłączona.",
     "topic-locked": "Temat zablokowany",
     "post-edit-duration-expired": "Możesz edytować posty tylko przez %1 sekund(y) po ich napisaniu",

--- a/public/language/pt-BR/error.json
+++ b/public/language/pt-BR/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "O teaser não existe",
     "no-flag": "Flag does not exist",
     "no-privileges": "Você não possui privilégios suficientes para esta ação.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Categoria desativada",
     "topic-locked": "Tópico Trancado",
     "post-edit-duration-expired": "Você só pode editar posts %1 segundo(s) após postar.",

--- a/public/language/pt-PT/error.json
+++ b/public/language/pt-PT/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Não existe pré-visualização",
     "no-flag": "Flag does not exist",
     "no-privileges": "Não possuis privilégios suficientes para esta ação.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Categoria desativada",
     "topic-locked": "Tópico bloqueado",
     "post-edit-duration-expired": "Só tens permissão para editar publicações %1 segundo(s) depois da sua publicação",

--- a/public/language/ro/error.json
+++ b/public/language/ro/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Teaser does not exist",
     "no-flag": "Flag does not exist",
     "no-privileges": "You do not have enough privileges for this action.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Categorie dezactivată",
     "topic-locked": "Subiect Închis",
     "post-edit-duration-expired": "You are only allowed to edit posts for %1 second(s) after posting",

--- a/public/language/ru/error.json
+++ b/public/language/ru/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Такого тизера не существует",
     "no-flag": "Flag does not exist",
     "no-privileges": "У вас недостаточно прав для этого действия.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Категория отключена",
     "topic-locked": "Тема закрыта",
     "post-edit-duration-expired": "Сообщения можно редактировать только в течение %1 с после публикации",

--- a/public/language/rw/error.json
+++ b/public/language/rw/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Inshamake itabaho",
     "no-flag": "Flag does not exist",
     "no-privileges": "Ntabwo uragira uburenganzira buhagije ngo wemererwe iki gikorwa",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Icyiciro cyabujijwe",
     "topic-locked": "Ikiganiro Cyafungiranywe",
     "post-edit-duration-expired": "Wemerewe gusa kugira icyo uhindura ku byo washyizeho nyuma y'amasegonda (isegonda) %1 nyuma yo kubishyiraho",

--- a/public/language/sk/error.json
+++ b/public/language/sk/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Ukážka neexistuje",
     "no-flag": "Flag does not exist",
     "no-privileges": "Na túto akciu nemáte dostatočné oprávnenia.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategória je zablokovaná",
     "topic-locked": "Téma je uzamknutá",
     "post-edit-duration-expired": "Upravovať príspevky môžete až za %1 sekúnd(y) po vytvorení",

--- a/public/language/sl/error.json
+++ b/public/language/sl/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Predogled ne obstaja.",
     "no-flag": "Flag does not exist",
     "no-privileges": "Nimate dovolj pravic za to dejanje.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorija je onemogočena.",
     "topic-locked": "Tema je zaklenjena.",
     "post-edit-duration-expired": "Urejanje objave je dovoljeno le %1 s po objavi.",

--- a/public/language/sq-AL/error.json
+++ b/public/language/sq-AL/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Përmbledhja nuk ekziston",
     "no-flag": "Flag does not exist",
     "no-privileges": "Nuk keni akses të mjaftueshem për këtë veprim.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategori e çaktivizuar",
     "topic-locked": "Temë e kyçur",
     "post-edit-duration-expired": "Ju lejohet të redaktoni postimet vetëm për %1 sekond(a) pas postimit",

--- a/public/language/sr/error.json
+++ b/public/language/sr/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Исечак не постоји",
     "no-flag": "Заставица не постоји",
     "no-privileges": "Немате довољне привилегије за обављање ове радње.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Категорија је онемогућена",
     "topic-locked": "Тема је закључана",
     "post-edit-duration-expired": "Време у којем вам је дозвољено уређивање порука након објављивања: %1 сек.",

--- a/public/language/sv/error.json
+++ b/public/language/sv/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Förhandsvisningen finns inte",
     "no-flag": "Flag does not exist",
     "no-privileges": "Du har inte tillräckliga rättigheter för den här åtgärden.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategorin inaktiverad",
     "topic-locked": "Ämnet låst",
     "post-edit-duration-expired": "Du kan endast ändra inlägg inom %1 sekund(er) efter att ha skickat det",

--- a/public/language/th/error.json
+++ b/public/language/th/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "ยังไม่มีทีเซอร์นี้",
     "no-flag": "Flag does not exist",
     "no-privileges": "คุณมีสิทธิ์ไม่เพียงพอที่จะทำรายการนี้",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Category นี้ถูกปิดการใช้งานแล้ว",
     "topic-locked": "กระทู้ถูกล็อก",
     "post-edit-duration-expired": "คุณได้รับอนุญาตให้แก้ไขโพสต์ได้หลังจากโพสต์ไปแล้ว %1  วินาที (s)",

--- a/public/language/tr/error.json
+++ b/public/language/tr/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "İleti Yok",
     "no-flag": "Şikayet Yok",
     "no-privileges": "Bu işlemi yapmak için yeterli yetkiniz yok.",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Kategori aktif değil",
     "topic-locked": "Başlık Kilitli",
     "post-edit-duration-expired": "Gönderilen iletiler %1 saniyeden sonra değiştirilemez",

--- a/public/language/uk/error.json
+++ b/public/language/uk/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Тизер не існує",
     "no-flag": "Flag does not exist",
     "no-privileges": "У вас недостатньо повноважень для цієї дії. ",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Категорію відключено",
     "topic-locked": "Тему заблоковано",
     "post-edit-duration-expired": "Ви можете редагувати пости лиш на протязі %1 секунд(и) з часу відправки",

--- a/public/language/vi/error.json
+++ b/public/language/vi/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "Đoạn giới thiệu không tồn tại",
     "no-flag": "Cờ không tồn tại",
     "no-privileges": "Bạn không đủ quyền để thực thi hành động này",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "Chuyên mục bị khóa",
     "topic-locked": "Chủ đề bị khóa",
     "post-edit-duration-expired": "Bạn chỉ được phép sửa bài viết sau khi đăng %1 giây.",

--- a/public/language/zh-CN/error.json
+++ b/public/language/zh-CN/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "主题预览不存在",
     "no-flag": "Flag does not exist",
     "no-privileges": "您没有权限执行此操作。",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "版块已禁用",
     "topic-locked": "主题已锁定",
     "post-edit-duration-expired": "您只能在发表后 %1 秒内修改内容",

--- a/public/language/zh-TW/error.json
+++ b/public/language/zh-TW/error.json
@@ -63,6 +63,7 @@
     "no-teaser": "主題預覽不存在",
     "no-flag": "Flag does not exist",
     "no-privileges": "您的權限不足以執行此操作。",
+    "instructor-only": "Your instructor disabled you to post announcements.",
     "category-disabled": "版面已停用",
     "topic-locked": "主題已鎖定",
     "post-edit-duration-expired": "您只能在發表後 %1 秒內修改內容",


### PR DESCRIPTION
Add an English text version of instructor only message to all language files.
Bug fix for #13 

In the future, we can actually translate to every single languages.